### PR TITLE
Add mailbox redundancy by using two providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # E2E Mailbox
-E2E test your email notification system using [GuerrillaMail API](https://www.guerrillamail.com/).
+
+E2E test your email notification system using [DeveloperMail API](https://www.developermail.com/) and [GuerrillaMail API](https://www.guerrillamail.com/).
 
 ## Description
-A fully-typed and tested JS library for adding email notification testing to your E2E tests. Some use-cases include:
-* Registering for site and checking for the welcome email 
-* Registering for a site and confirming your email address by pulling the URL from the email body
-* Fetching a reset password pin from an email
-* Ensuring your system sends the correct email after an action is committed on your website
 
+A fully-typed and tested JS library for adding email notification testing to your E2E tests. Some use-cases include:
+
+- Registering for site and checking for the welcome email
+- Registering for a site and confirming your email address by pulling the URL from the email body
+- Fetching a reset password pin from an email
+- Ensuring your system sends the correct email after an action is committed on your website
+
+Configurable to use either DeveloperMail or GuerrillaMail as the temporary mailbox providers. If one is not working, the other will be used automatically to prevent disruption.
 
 ## Usage
 
@@ -19,73 +23,103 @@ Install the **E2E Mailbox** package with [NPM](https://www.npmjs.com/package/e2e
 npm install e2e-mailbox
 yarn add e2e-mailbox
 ```
-### Setup
-#### Creating an Email Address
-```js
-import E2EMailbox from 'e2e-mailbox'
 
+### Setup
+
+#### Creating an Email Address
+
+```js
+import E2EMailbox from 'e2e-mailbox';
+// This will create a new mailbox using DeveloperAPI as the provider.
+// To set GuerrillaMail, pass 'GUERRILLA' to the constructor.
 const mailbox = new E2EMailbox();
 // This will generate a new email address for you to use in your tests
 const emailAddress = await mailbox.createEmailAddress();
 ```
+
 #### Wait for Email by Subject Line
+
 After an email has been sent to the email address, you could poll for the email's subject line explicitly:
+
 ```js
 // Set the subject line along with the max timeout in seconds, default is 60 seconds.
 const email = await mailbox.waitForEmail('The Subject Line in your Email', 60);
 
 // or you could use the promise chains if you fancy
-mailbox.waitForEmail('The Subject Line in your Email').then(email => {
-  if (!email) { return; }
+mailbox.waitForEmail('The Subject Line in your Email').then((email) => {
+  if (!email) {
+    return;
+  }
   // email is found and safe to use now.
 });
 ```
+
 #### Fetch All Emails in Mailbox
+
 ```js
 // Returns an array of email responses
 const emailList = await mailbox.fetchEmailList();
 ```
+
 #### Fetch Email by ID
+
 Each email has an `email_id` associated with it, this ID could be used to fetch all attachments and body of an email.
+
 ```js
 const fullEmail = await mailbox.fetchEmailById(emailID);
 ```
+
 #### Delete Email by ID
+
 ```js
 const isEmailDeleted = await mailbox.deleteEmailById(email.mail_id);
 ```
+
 ### Example Usage in Tests
+
 #### Checking if email was generated
+
 The first test in the suite should generate a new email to be used by later tests.
+
 ```js
 const mailbox = new IntegrationMailbox();
 let emailAddress = '';
 test('should generate an email properly', async () => {
-    emailAddress = await mailbox.createEmailAddress();
-    expect(emailAddress).toBeDefined();
+  emailAddress = await mailbox.createEmailAddress();
+  expect(emailAddress).toBeDefined();
 });
 ```
+
 #### Checking if email was sent
+
 After registering for your service during the integration test, we should test to make sure the email was sent out in a timely manner.
+
 ```js
-  it('should send a confirm account email', async () => {
-    // 'Confirm Your Email' is the subject line of the email in this case
-    const foundEmail = await mailbox.waitForEmail('Confirm Your Email', 100);
-    expect(!!foundEmail).toBeTruthy();
-  });
+it('should send a confirm account email', async () => {
+  // 'Confirm Your Email' is the subject line of the email in this case
+  const foundEmail = await mailbox.waitForEmail('Confirm Your Email', 100);
+  expect(!!foundEmail).toBeTruthy();
+});
 ```
+
 Next, if you have a confirmation link in the email, you could pull it from the email body:
+
 ```js
-  it('should confirm account and go to login page', async () => {
-    expect(foundEmail).toBeDefined();
-    if (!foundEmail) { return; }
-    const urls = mailbox.extractLinksFromEmail(foundEmail);
-    const confirmUrl = urls.filter(url => url.includes('https://example.com/your_confirm_url'))[0];
-    expect(confirmUrl).toBeDefined();
-    if (!confirmUrl) { return; }
-    // navigate to your confirmUrl in your test
-  });
+it('should confirm account and go to login page', async () => {
+  expect(foundEmail).toBeDefined();
+  if (!foundEmail) {
+    return;
+  }
+  const urls = mailbox.extractLinksFromEmail(foundEmail);
+  const confirmUrl = urls.filter((url) => url.includes('https://example.com/your_confirm_url'))[0];
+  expect(confirmUrl).toBeDefined();
+  if (!confirmUrl) {
+    return;
+  }
+  // navigate to your confirmUrl in your test
+});
 ```
+
 ## License
 
 This library is released under the

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fully-typed and tested JS library for adding email notification testing to you
 - Fetching a reset password pin from an email
 - Ensuring your system sends the correct email after an action is committed on your website
 
-Configurable to use either DeveloperMail or GuerrillaMail as the temporary mailbox providers. If one is not working, the other will be used automatically to prevent disruption.
+Configurable to use either DeveloperMail or GuerrillaMail as the temporary mailbox providers. These are free services generously provided to create short-lived emails addresses. If one provider is not working, the other will be used automatically to prevent disruption.
 
 ## Usage
 
@@ -30,7 +30,7 @@ yarn add e2e-mailbox
 
 ```js
 import E2EMailbox from 'e2e-mailbox';
-// This will create a new mailbox using DeveloperAPI as the provider.
+// This will create a new mailbox using DeveloperMail API as the provider.
 // To set GuerrillaMail, pass 'GUERRILLA' to the constructor.
 const mailbox = new E2EMailbox();
 // This will generate a new email address for you to use in your tests

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "typescript": "^4.3.4"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "@types/mailparser": "^3.0.3",
+    "axios": "^0.21.1",
+    "mailparser": "^3.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,8 @@ import axios, { AxiosResponse } from 'axios';
 import DeveloperMailService from './services/developerMailService';
 import GuerrillaMailService from './services/guerrillaMailService';
 import MailboxService from './services/mailboxService';
-import { CreateEmailResponse, EmailResponse, SetEmailResponse } from './types';
+import { EmailResponse, MailboxProvider } from './types';
 
-type MailboxProvider = 'DEVELOPER' | 'GUERRILLA';
 const noMailboxError = 'There is currently no mailbox set. Did you forget to call `createEmailAddress` first?';
 
 export default class IntegrationMailbox {
@@ -17,6 +16,10 @@ export default class IntegrationMailbox {
     private mailbox: MailboxService | undefined;
 
     /** --- Public Functions --- */
+
+    constructor(mailboxProvider: MailboxProvider = 'DEVELOPER') {
+        this.mailbox = this.mailboxProviders[mailboxProvider];
+    }
 
     /**
      * Initialize a session and set the client with an email address. If the session already exists, 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,15 +17,19 @@ export default class IntegrationMailbox {
 
     /** --- Public Functions --- */
 
+    /**
+     * Creates a mailbox session with the designated provider. By default
+     * DeveloperMail API will be used. 
+     * @param mailboxProvider 
+     */
     constructor(mailboxProvider: MailboxProvider = 'DEVELOPER') {
         this.mailbox = this.mailboxProviders[mailboxProvider];
     }
 
     /**
-     * Initialize a session and set the client with an email address. If the session already exists, 
-     * then it will return the email address details of the existing session. If a new session needs to be created, then it
-     * will first check for the SUBSCR cookie to create a session for a subscribed address, otherwise it will create new email
-     * address randomly.
+     * Initialize a session and set the client with an email address. 
+     * If one email service is not working, the backup will be used 
+     * automatically to prevent disruption.
      * @returns email address
      */
     async createEmailAddress(): Promise<string | undefined> {
@@ -33,7 +37,9 @@ export default class IntegrationMailbox {
         let email = await this.mailbox.createEmailAddress();
         // If service cannot create an address, use the opposite provider.
         if (!email) {
-            const newMailbox: MailboxProvider = this.mailbox.PROVIDER === 'DEVELOPER' ? 'GUERRILLA' : 'DEVELOPER';
+            const newMailbox: MailboxProvider = this.mailbox.PROVIDER === 'DEVELOPER'
+                ? 'GUERRILLA'
+                : 'DEVELOPER';
             this.mailbox = this.mailboxProviders[newMailbox];
             // Attempt to create an email address again using a different provider.
             email = await this.mailbox.createEmailAddress();
@@ -52,10 +58,8 @@ export default class IntegrationMailbox {
     }
 
     /**
-     * Forget the current email address. This will not stop the session, the existing session will be maintained.
-     * A subsequent call to get_email_address will fetch a new email address or the client can call set_email_user
-     * to set a new address. Typically, a user would want to set a new address manually after clicking the 
-     * ‘forget me’ button.
+     * Forget the current email address. This will delete the mailbox and any emails 
+     * it contains.
      * @param emailAddress 
      * @returns True on success, false on failure
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,16 @@ export default class IntegrationMailbox {
      * address randomly.
      * @returns email address
      */
-    async createEmailAddress(mailboxProvider: MailboxProvider = 'DEVELOPER'): Promise<string | undefined> {
-        this.mailbox = this.mailboxProviders[mailboxProvider];
-        const email = await this.mailbox.createEmailAddress();
+    async createEmailAddress(): Promise<string | undefined> {
+        if (!this.mailbox) { throw Error(noMailboxError); }
+        let email = await this.mailbox.createEmailAddress();
+        // If service cannot create an address, use the opposite provider.
+        if (!email) {
+            const newMailbox: MailboxProvider = this.mailbox.PROVIDER === 'DEVELOPER' ? 'GUERRILLA' : 'DEVELOPER';
+            this.mailbox = this.mailboxProviders[newMailbox];
+            // Attempt to create an email address again using a different provider.
+            email = await this.mailbox.createEmailAddress();
+        }
         return email;
     }
 

--- a/src/services/developerMailService.ts
+++ b/src/services/developerMailService.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse, Method } from 'axios';
-import { EmailResponse } from '../types';
+import { EmailResponse, MailboxProvider } from '../types';
 import MailboxService from './mailboxService';
 
 interface CreateEmailResponse {

--- a/src/services/developerMailService.ts
+++ b/src/services/developerMailService.ts
@@ -1,0 +1,140 @@
+import axios, { AxiosResponse, Method } from 'axios';
+import { EmailResponse } from '../types';
+import MailboxService from './mailboxService';
+
+interface CreateEmailResponse {
+    name: string;
+    token: string;
+}
+
+interface MessageIdsResponse {
+    result: string[];
+}
+interface GetMessagesResponse {
+    result: { key: string, value: string }[];
+}
+
+class DeveloperMailService extends MailboxService {
+    API_URL = 'https://www.developermail.com/api/v1';
+    private token = '';
+    private mailboxName = '';
+
+    private async sendRequest(params: any, method: Method, endpoint: string): Promise<AxiosResponse | undefined> {
+        try {
+            // Set Authentication header for DeveloperMail
+            const headers = !!this.token ? {} : {
+                'X-MailboxToken': this.token
+            };
+            const response = await axios(`${this.API_URL}${endpoint}`, {
+                params, method, headers
+            });
+            return response;
+        } catch (error) {
+            if (!error.data) { return; }
+        }
+    }
+
+    /**
+     * Initialize a session and set the client with an email address. If the session already exists, 
+     * then it will return the email address details of the existing session. If a new session needs to be created, then it
+     * will first check for the SUBSCR cookie to create a session for a subscribed address, otherwise it will create new email
+     * address randomly.
+     * @returns email address
+     */
+    async createEmailAddress(): Promise<string | undefined> {
+        const response = await this.sendRequest({}, 'PUT', '/mailbox');
+        if (!response) { return; }
+        const creationResponse: CreateEmailResponse = response.data.result;
+        const EMAIL_DOMAIN = 'developermail.com';
+        this.token = creationResponse.token;
+        this.mailboxName = creationResponse.name;
+        return `${creationResponse.name}@${EMAIL_DOMAIN}`;
+    }
+
+    /**
+     * Get the current list of emails from the email inbox.
+     * @returns Array of emails
+     */
+    async fetchEmailList(): Promise<EmailResponse[]> {
+        const emailList: EmailResponse[] = [];
+        // Fetch list of message IDs present in the mailbox
+        const getMessageIdsResponse = await this.sendRequest({}, 'GET', `/mailbox/${this.mailboxName}`);
+        if (!getMessageIdsResponse) { return emailList; }
+        const emailListResponse: MessageIdsResponse = getMessageIdsResponse.data;
+
+        // Fetch list of messages from the IDs gathered in getMessageIdsResponse
+        const getMessagesResponse = await this.sendRequest(
+            emailListResponse.result, 'POST', `/mailbox/${this.mailboxName}`
+        );
+        if (!getMessagesResponse) { return emailList; }
+        const messages: GetMessagesResponse = getMessagesResponse.data;
+
+        // Response value comes as Mime 1.0, we must parse this to conform with our
+        // read model.
+        messages.result.forEach(message => {
+            const splitResponse = message.value.split('\r\n');
+            const messageFrom = splitResponse[1].split('From: ')[1];
+            const messageDate = splitResponse[3].split('Date: ')[1];
+            const messageSubject = splitResponse[4].split('Subject: ')[1];
+            const messageBody = splitResponse[6].split('Content-Transfer-Encoding: ')[1];
+            // v1.0 read model was tied to GuerrillaMail's response type, for
+            // compatibility-sake we will convert DeveloperMail to the same type.
+            const email: EmailResponse = {
+                mail_id: message.key,
+                mail_from: messageFrom,
+                mail_timestamp: messageDate,
+                mail_subject: messageSubject,
+                mail_excerpt: '',
+                mail_body: messageBody
+            };
+            emailList.push(email);
+        })
+        return emailList;
+    }
+
+    /**
+     * Forget the current email address. This will not stop the session, the existing session will be maintained.
+     * A subsequent call to get_email_address will fetch a new email address or the client can call set_email_user
+     * to set a new address. Typically, a user would want to set a new address manually after clicking the 
+     * ‘forget me’ button.
+     * @param emailAddress 
+     * @returns True on success, false on failure
+     */
+    async forgetEmailAddress(): Promise<boolean | undefined> {
+        const response = await this.sendRequest({}, 'DELETE', `/mailbox/${this.mailboxName}`);
+        if (!response) { return; }
+        const responseData: boolean = response.data.result;
+        return responseData;
+    }
+
+    /**
+     * Delete a specific email by ID.
+     * @param emailId 
+     * @returns true on success, false on failure
+     */
+    async deleteEmailById(emailId: string): Promise<boolean | undefined> {
+        const response = await this.sendRequest(
+            {}, 'DELETE', `/mailbox/${this.mailboxName}/messages/{${emailId}}`
+        );
+        if (!response) { return false; }
+        return response.data.result;
+    }
+
+    /**
+     * Get the contents of an email. All HTML in the body of the email is filtered. 
+     * Eg, Javascript, applets, iframes, etc is removed. Subject and email excerpt are escaped using HTML Entities.
+     * Only emails owned by the current session id can be fetched.
+     * @param emailId 
+     * @returns 
+     */
+    async fetchEmailById(emailId: string): Promise<EmailResponse | undefined> {
+        const response = await this.sendRequest(
+            {}, 'GET', `/mailbox/${this.mailboxName}/messages/${emailId}`
+        );
+        if (!response) { return; }
+        const responseData: EmailResponse = response.data;
+        return responseData;
+    }
+}
+
+export default DeveloperMailService;

--- a/src/services/developerMailService.ts
+++ b/src/services/developerMailService.ts
@@ -29,6 +29,13 @@ class DeveloperMailService extends MailboxService {
     private token = '';
     private mailboxName = '';
 
+    /**
+     * Send request to DeveloperMail API.
+     * @param data 
+     * @param method 
+     * @param endpoint 
+     * @returns AxiosResponse on success, undefined on failure.
+     */
     private async sendRequest(data: any, method: Method, endpoint: string): Promise<AxiosResponse | undefined> {
         try {
             // Set Authentication header for DeveloperMail
@@ -46,7 +53,13 @@ class DeveloperMailService extends MailboxService {
         }
     }
 
-    private async buildEmailResponse(message: string, mailId: string): Promise<EmailResponse> {
+    /**
+     * Convert Mime-Type response from DeveloperMail to EmailResponse
+     * @param message 
+     * @param mailId 
+     * @returns generated EmailResponse
+     */
+    private async convertMimeToEmailResponse(message: string, mailId: string): Promise<EmailResponse> {
         const parsedMessage: ParsedMail = await simpleParser(message);
         const messageFrom = !!parsedMessage.from ? parsedMessage.from.text : '';
         const messageDate = parsedMessage.date ? `${parsedMessage.date.getTime()}` : '';
@@ -103,7 +116,7 @@ class DeveloperMailService extends MailboxService {
         // Response value comes as Mime 1.0, we must parse this to conform with our
         // read model.
         for (const message of messages.result) {
-            const email = await this.buildEmailResponse(message.value, message.key);
+            const email = await this.convertMimeToEmailResponse(message.value, message.key);
             emailList.push(email);
         }
 
@@ -151,7 +164,7 @@ class DeveloperMailService extends MailboxService {
         );
         if (!response) { return; }
         const responseData: string = response.data.result;
-        const email: EmailResponse = await this.buildEmailResponse(responseData, emailId);
+        const email: EmailResponse = await this.convertMimeToEmailResponse(responseData, emailId);
         return email;
     }
 

--- a/src/services/developerMailService.ts
+++ b/src/services/developerMailService.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse, Method } from 'axios';
 import { EmailResponse, MailboxProvider } from '../types';
 import MailboxService from './mailboxService';
+import { ParsedMail, simpleParser } from 'mailparser';
 
 interface CreateEmailResponse {
     name: string;

--- a/src/services/developerMailService.ts
+++ b/src/services/developerMailService.ts
@@ -102,7 +102,7 @@ class DeveloperMailService extends MailboxService {
 
         // Response value comes as Mime 1.0, we must parse this to conform with our
         // read model.
-        for (let message of messages.result) {
+        for (const message of messages.result) {
             const email = await this.buildEmailResponse(message.value, message.key);
             emailList.push(email);
         }

--- a/src/services/guerrillaMailService.ts
+++ b/src/services/guerrillaMailService.ts
@@ -1,0 +1,126 @@
+import axios, { AxiosResponse } from 'axios';
+import { CreateEmailResponse, EmailListResponse, EmailResponse, SetEmailResponse } from '../types';
+import MailboxService from './mailboxService';
+
+class GuerrillaMailService extends MailboxService {
+    API_URL = 'http://api.guerrillamail.com/ajax.php';
+    private sidToken = '';
+
+    private async sendRequest(payload: any, isRetry = 0): Promise<AxiosResponse | undefined> {
+        try {
+            // "ip" and "agent" are required parameters, those values were taken straight from
+            // Guerilla's API docs.
+            const params = {
+                ...payload, sid_token: this.sidToken, ip: '127.0.0.1', agent: 'Mozilla_foo_bar',
+            };
+            const response = await axios.get(this.API_URL, { params });
+            return response;
+        } catch (error) {
+            if (!error.data) { return; }
+            // Automatically retry 3 times if it's a 502 error
+            if (error.data.includes('502 Bad Gateway') && isRetry < 3) {
+                // Wait 3 seconds before retrying if there's a 502 error.
+                await this.sleep(3000);
+                const response = await this.sendRequest(payload, isRetry + 1);
+                return response;
+            }
+        }
+    }
+
+
+    /**
+     * Initialize a session and set the client with an email address. If the session already exists, 
+     * then it will return the email address details of the existing session. If a new session needs to be created, then it
+     * will first check for the SUBSCR cookie to create a session for a subscribed address, otherwise it will create new email
+     * address randomly.
+     * @returns email address
+     */
+    async createEmailAddress(): Promise<string | undefined> {
+        const payload = { f: 'get_email_address' };
+        const response = await this.sendRequest(payload);
+        if (!response) { return; }
+        const creationResponse: CreateEmailResponse = response.data;
+        this.sidToken = creationResponse.sid_token;
+        return creationResponse.email_addr;
+    }
+
+    /**
+     * Get the current list of emails from the email inbox.
+     * @returns Array of emails
+     */
+    async fetchEmailList(): Promise<EmailResponse[]> {
+        let emailList: EmailResponse[] = [];
+        const payload = { f: 'get_email_list', offset: 0 };
+        const response = await this.sendRequest(payload);
+        if (!response) { return emailList; }
+        const emailListResponse: EmailListResponse = response.data;
+        emailList = emailListResponse.list;
+        return emailList;
+    }
+
+
+    /**
+     * Set the email address to a different email address. If the email address is a subscriber, 
+     * then return the subscription details. If the email is not a subscriber, then the email address
+     * will be given 60 minutes again. A new email address will be generated if the email address is 
+     * not in the database and a welcome email message will be generated.
+     * @param emailAddress 
+     * @returns True on success, false on failure
+     */
+    async setEmailAddress(emailAddress: string): Promise<SetEmailResponse | undefined> {
+        // If a full email is passed, only use the username portion.
+        const emailUsername = emailAddress.split('@')[0];
+        const payload = { f: 'set_email_user', lang: 'en', email_user: emailUsername };
+        const response = await this.sendRequest(payload);
+        if (!response) { return; }
+        const responseData: SetEmailResponse = response.data;
+        return responseData;
+    }
+
+    /**
+     * Forget the current email address. This will not stop the session, the existing session will be maintained.
+     * A subsequent call to get_email_address will fetch a new email address or the client can call set_email_user
+     * to set a new address. Typically, a user would want to set a new address manually after clicking the 
+     * ‘forget me’ button.
+     * @param emailAddress 
+     * @returns True on success, false on failure
+     */
+    async forgetEmailAddress(emailAddress: string): Promise<boolean | undefined> {
+        const payload = { f: 'forget_me', lang: 'en', email_addr: emailAddress };
+        const response = await this.sendRequest(payload);
+        if (!response) { return; }
+        const responseData: boolean = response.data;
+        return responseData;
+    }
+
+    /**
+     * Delete a specific email by ID.
+     * @param emailId 
+     * @returns true on success, false on failure
+     */
+    async deleteEmailById(emailId: string): Promise<boolean | undefined> {
+        const payload = { f: 'del_email', lang: 'en', 'email_ids[]': emailId };
+        const response = await this.sendRequest(payload);
+        if (!response) { return; }
+        const responseData: string = response.data;
+        // API returns an empty string as body on success.
+        return !!responseData;
+    }
+
+    /**
+     * Get the contents of an email. All HTML in the body of the email is filtered. 
+     * Eg, Javascript, applets, iframes, etc is removed. Subject and email excerpt are escaped using HTML Entities.
+     * Only emails owned by the current session id can be fetched.
+     * @param emailId 
+     * @returns 
+     */
+    async fetchEmailById(emailId: string): Promise<EmailResponse | undefined> {
+        const payload = { f: 'fetch_email', email_id: emailId };
+        const response = await this.sendRequest(payload);
+        if (!response) { return; }
+        const responseData: EmailResponse = response.data;
+        return responseData;
+    }
+}
+
+export default GuerrillaMailService;

--- a/src/services/guerrillaMailService.ts
+++ b/src/services/guerrillaMailService.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
-import { CreateEmailResponse, EmailListResponse, EmailResponse, SetEmailResponse } from '../types';
+import { CreateEmailResponse, EmailListResponse, EmailResponse, MailboxProvider, SetEmailResponse } from '../types';
 import MailboxService from './mailboxService';
 
 class GuerrillaMailService extends MailboxService {
     API_URL = 'http://api.guerrillamail.com/ajax.php';
+    PROVIDER: MailboxProvider = 'GUERRILLA';
     private sidToken = '';
 
     private async sendRequest(payload: any, isRetry = 0): Promise<AxiosResponse | undefined> {

--- a/src/services/guerrillaMailService.ts
+++ b/src/services/guerrillaMailService.ts
@@ -7,6 +7,12 @@ class GuerrillaMailService extends MailboxService {
     PROVIDER: MailboxProvider = 'GUERRILLA';
     private sidToken = '';
 
+    /**
+     * Send request to the GuerrillaMail API.
+     * @param payload 
+     * @param isRetry 
+     * @returns AxiosResponse on success, undefined on failure.
+     */
     private async sendRequest(payload: any, isRetry = 0): Promise<AxiosResponse | undefined> {
         try {
             // "ip" and "agent" are required parameters, those values were taken straight from

--- a/src/services/mailboxService.ts
+++ b/src/services/mailboxService.ts
@@ -1,0 +1,51 @@
+import { EmailResponse } from '../types';
+
+abstract class MailboxService {
+    abstract API_URL: string;
+
+    async sleep(timeInMs: number): Promise<void> {
+        await new Promise(r => setTimeout(r, timeInMs));
+    }
+
+    /** --- Public Functions --- */
+
+    /**
+     * Initialize a session and set the client with an email address.
+     * @returns email address
+     */
+    abstract createEmailAddress(): Promise<string | undefined>;
+
+
+    /**
+     * Get the current list of emails from the email inbox.
+     * @returns Array of emails
+     */
+    abstract fetchEmailList(): Promise<EmailResponse[]>;
+
+
+    /**
+     * Forget the current email address. 
+     * @param emailAddress 
+     * @returns True on success, false on failure
+     */
+    abstract forgetEmailAddress(emailAddress: string): Promise<boolean | undefined>;
+
+    /**
+     * Delete a specific email by ID.
+     * @param emailId 
+     * @returns true on success, false on failure
+     */
+    abstract deleteEmailById(emailId: string): Promise<boolean | undefined>;
+
+    /**
+     * Get the contents of an email. All HTML in the body of the email is filtered. 
+     * Eg, Javascript, applets, iframes, etc is removed. Subject and email excerpt are escaped using HTML Entities.
+     * Only emails owned by the current session id can be fetched.
+     * @param emailId 
+     * @returns 
+     */
+    abstract fetchEmailById(emailId: string): Promise<EmailResponse | undefined>;
+
+}
+
+export default MailboxService;

--- a/src/services/mailboxService.ts
+++ b/src/services/mailboxService.ts
@@ -1,7 +1,8 @@
-import { EmailResponse } from '../types';
+import { EmailResponse, MailboxProvider } from '../types';
 
 abstract class MailboxService {
     abstract API_URL: string;
+    abstract PROVIDER: MailboxProvider;
 
     async sleep(timeInMs: number): Promise<void> {
         await new Promise(r => setTimeout(r, timeInMs));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,28 @@
+export interface CreateEmailResponse {
+    email_addr: string;
+    email_timestamp: number;
+    alias: string;
+    sid_token: string;
+}
+
+export interface EmailListResponse {
+    list: EmailResponse[];
+}
+
+export interface EmailResponse {
+    mail_id: string;
+    mail_from: string;
+    mail_timestamp: string;
+    mail_subject: string;
+    mail_excerpt: string;
+    mail_body: string;
+}
+
+export interface SetEmailResponse {
+    email_addr: string;
+    email_timestamp: string;
+    s_active: string;
+    s_date: string;
+    s_time: string;
+    s_time_expires: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type MailboxProvider = 'DEVELOPER' | 'GUERRILLA';
+
 export interface CreateEmailResponse {
     email_addr: string;
     email_timestamp: number;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,4 +1,5 @@
-import E2EMailbox, { EmailResponse } from '../src/index';
+import E2EMailbox from '../src/index';
+import { EmailResponse } from '../src/types';
 
 const mailbox = new E2EMailbox();
 let emailList: Array<EmailResponse> = [];
@@ -12,7 +13,9 @@ test('should generate an email properly', async () => {
 });
 
 test('should return an email list with one email', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
+    const foundEmail = await mailbox.waitForEmail('Welcome to DeveloperMail.com!');
+    expect(foundEmail).toBeDefined();
     emailList = await mailbox.fetchEmailList();
     expect(emailList.length).toEqual(1);
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,7 +1,7 @@
 import E2EMailbox from '../src/index';
 import { EmailResponse } from '../src/types';
 
-const mailbox = new E2EMailbox();
+const mailbox = new E2EMailbox('GUERRILLA');
 let emailList: Array<EmailResponse> = [];
 let emailAddress: string | undefined = '';
 test('should generate an email properly', async () => {
@@ -14,7 +14,7 @@ test('should generate an email properly', async () => {
 
 test('should return an email list with one email', async () => {
     expect.assertions(2);
-    const foundEmail = await mailbox.waitForEmail('Welcome to DeveloperMail.com!');
+    const foundEmail = await mailbox.waitForEmail('Welcome');
     expect(foundEmail).toBeDefined();
     emailList = await mailbox.fetchEmailList();
     expect(emailList.length).toEqual(1);
@@ -25,7 +25,7 @@ test('should fetch email by ID', async () => {
     const fullEmail = await mailbox.fetchEmailById(emailList[0].mail_id);
     expect(fullEmail).toBeDefined();
     if (!fullEmail) { return; }
-    expect(fullEmail.mail_body.length).toBeGreaterThan(250);
+    expect(fullEmail.mail_body.length).toBeGreaterThan(150);
 });
 
 test('should wait for email', async () => {

--- a/tests/developermail.test.ts
+++ b/tests/developermail.test.ts
@@ -1,0 +1,48 @@
+import DeveloperMailService from '../src/services/developerMailService';
+import { EmailResponse } from '../src/types';
+
+const dmMailbox = new DeveloperMailService()
+let dmEmailAddress: string | undefined;
+const subjectLine = 'Welcome!';
+let emailList: EmailResponse[] = [];
+
+test('should generate an email for DeveloperMail properly', async () => {
+    expect.assertions(2);
+    dmEmailAddress = await dmMailbox.createEmailAddress();
+    expect(dmEmailAddress).toBeDefined();
+    if (!dmEmailAddress) { return; }
+    expect(dmEmailAddress.includes('@')).toBeTruthy();
+});
+
+test('should send an email to own mailbox', async () => {
+    expect.assertions(1);
+    const emailHasSent = await dmMailbox.sendSelfMail(subjectLine, 'Testing email body.');
+    expect(emailHasSent).toBeTruthy();
+});
+
+test('email should arrive in inbox', async () => {
+    expect.assertions(2);
+    await new Promise(r => setTimeout(r, 10000));
+    emailList = await dmMailbox.fetchEmailList();
+    expect(emailList.length).toEqual(1);
+    if (emailList.length === 0) { return; }
+    expect(emailList[0].mail_subject.includes(subjectLine)).toBeTruthy();
+});
+
+
+test('should delete email by ID', async () => {
+    expect.assertions(2);
+    const isEmailDeleted = await dmMailbox.deleteEmailById(emailList[0].mail_id);
+    expect(isEmailDeleted).toBeTruthy();
+    if (!isEmailDeleted) { return; }
+    const secondEmailList = await dmMailbox.fetchEmailList();
+    expect(secondEmailList.length).toEqual(0);
+});
+
+test('should forget email address', async () => {
+    expect.assertions(2);
+    expect(dmEmailAddress).toBeDefined();
+    if (!dmEmailAddress) { return; }
+    const isEmailForgotten = await dmMailbox.forgetEmailAddress();
+    expect(isEmailForgotten).toBeTruthy();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,6 +584,13 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/mailparser@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mailparser/-/mailparser-3.0.3.tgz#934c1637728eefd9ad2eb797878cb3d938909973"
+  integrity sha512-R2TXAQFZD33kVlaaZpfBKQLR6uEuiTh8FoPyaQnVkstb/TnWSKQ93F78Kb3/dAESGhPEEQ7jCPWfN/SLUZD6Jg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "15.12.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
@@ -1043,12 +1050,42 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
+  integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 electron-to-chromium@^1.3.723:
   version "1.3.758"
@@ -1064,6 +1101,16 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+encoding-japanese@1.0.30:
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/encoding-japanese/-/encoding-japanese-1.0.30.tgz#537c4d62881767925d601acb4c79fb14db81703a"
+  integrity sha512-bd/DFLAoJetvv7ar/KIpE3CNO8wEuyrt9Xuw6nSMiZ+Vrz/Q21BPsMHvARL2Wz6IKHKXgb+DWZqtRg1vql9cBg==
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1259,6 +1306,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+he@1.2.0, he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -1270,6 +1322,26 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-to-text@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-7.0.0.tgz#97ff0bcf34241c282f78f5c1baa05dfa44d9d3c3"
+  integrity sha512-UR/WMSHRN8m+L7qQUhbSoxylwBovNPS+xURn/pHeJvbnemhyMiuPYBTBGqB6s8ajAARN5jzKfF0d3CY86VANpA==
+  dependencies:
+    deepmerge "^4.2.2"
+    he "^1.2.0"
+    htmlparser2 "^6.0.0"
+    minimist "^1.2.5"
+
+htmlparser2@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -1299,6 +1371,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 import-local@^3.0.2:
   version "3.0.2"
@@ -1916,6 +1995,33 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libbase64@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/libbase64/-/libbase64-1.2.1.tgz#fb93bf4cb6d730f29b92155b6408d1bd2176a8c8"
+  integrity sha512-l+nePcPbIG1fNlqMzrh68MLkX/gTxk/+vdvAb388Ssi7UuUN31MI44w4Yf33mM3Cm4xDfw48mdf3rkdHszLNew==
+
+libmime@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/libmime/-/libmime-5.0.0.tgz#4759c76eb219985c5d4057b3a9359922194d9ff7"
+  integrity sha512-2Bm96d5ktnE217Ib1FldvUaPAaOst6GtZrsxJCwnJgi9lnsoAKIHyU0sae8rNx6DNYbjdqqh8lv5/b9poD8qOg==
+  dependencies:
+    encoding-japanese "1.0.30"
+    iconv-lite "0.6.2"
+    libbase64 "1.2.1"
+    libqp "1.1.0"
+
+libqp@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/libqp/-/libqp-1.1.0.tgz#f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8"
+  integrity sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=
+
+linkify-it@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -1934,6 +2040,30 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+mailparser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mailparser/-/mailparser-3.2.0.tgz#cb0c4794590ba491ba2c920669ed72e472e51531"
+  integrity sha512-UpAC45oeYjp4Aa/z7XuG+PpElI+pkHpuomGcSeL1zH8gEo7anqoFY0X58ZHf0CdQIpFzp2qCPa5h905VDVUUgQ==
+  dependencies:
+    encoding-japanese "1.0.30"
+    he "1.2.0"
+    html-to-text "7.0.0"
+    iconv-lite "0.6.2"
+    libmime "5.0.0"
+    linkify-it "3.0.2"
+    mailsplit "5.0.1"
+    nodemailer "6.5.0"
+    tlds "1.219.0"
+
+mailsplit@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mailsplit/-/mailsplit-5.0.1.tgz#070bd883bddc0c6c7f5c6ea4a54847729d95dc6f"
+  integrity sha512-CcGy1sv8j9jdjKiNIuMZYIKhq4s47nUj9Q98BZfptabH/whmiQX7EvrHx36O4DcyPEsnG152GVNyvqPi9FNIew==
+  dependencies:
+    libbase64 "1.2.1"
+    libmime "5.0.0"
+    libqp "1.1.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -2032,6 +2162,11 @@ node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+
+nodemailer@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.5.0.tgz#d12c28d8d48778918e25f1999d97910231b175d9"
+  integrity sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -2234,7 +2369,7 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -2415,6 +2550,11 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
+tlds@1.219.0:
+  version "1.219.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.219.0.tgz#7e636062386a1f3c9184356de93d40842ffe91d9"
+  integrity sha512-o4g9c8kXCmTDwUnK/9HpTT9o/GNH85KCvs+S5SgUw5yILdECvMmTGzK7ngoWMp97P5tfYr8fZeF16YhgV/l90A==
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -2528,6 +2668,11 @@ typescript@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+
+uc.micro@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Support use of both GuerrillaMail and DeveloperMail to add redundancy in the event one provider is not working. By default, the library will use DeveloperMail, this could be changed by passing `GUERRILLA` into the E2EMailbox constructor. If DeveloperMail API cannot create a mailbox, GuerrillaMail will be used as a fallback to prevent disruptions. 