### PR TITLE
Allow axios to be updated to a newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-mailbox",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "E2E test your email notification system using GuerrillaMail API.",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.mjs",
@@ -41,7 +41,7 @@
     "typescript": "^4.3.4"
   },
   "dependencies": {
-    "axios": "1.7.4",
+    "axios": "^1.7.4",
     "mailparser": "^3.6.5"
   },
   "files": [


### PR DESCRIPTION
Hi Allyn

There is a high vulnerability in axios versions lower 1.8.2. Therefor it would be nice, to not have it fixed to 1.7.4.

```
axios  >=1.0.0 <1.8.2
  (direct dependency)
  high: axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL - https://github.com/advisories/GHSA-jr5f-v2jv-69x6
```

Thank you and regards.
Andy